### PR TITLE
Added dockerfile and k8s files

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,19 @@
+FROM golang:latest
+RUN go get -v -u github.com/gorilla/mux
+RUN apt-get update \
+    && apt-get install -y \
+    golang
+
+# Set the Current Working Directory inside the container
+WORKDIR /app/go-cal-app
+
+COPY . /app/go-cal-app
+
+# Build the Go app
+RUN go build -o gocalpage
+
+# This container exposes port 8080 to the outside world
+EXPOSE 8080
+
+# Run the binary program produced by `go install`
+CMD ["./gocalpage"]

--- a/golang-deploy.yaml
+++ b/golang-deploy.yaml
@@ -1,0 +1,23 @@
+---
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      name: golang-deployment
+      labels:
+        app: golang-app
+    spec:
+      replicas: 1
+      selector:
+        matchLabels:
+          app: golang-app
+      template:
+        metadata: 
+          labels:
+            app: golang-app
+        spec:
+          containers:
+          - name: golang-container
+            image: srikanthdevops99/golang:v1
+            ports:
+            - containerPort: 8080
+... 

--- a/golang-svc-lb.yaml
+++ b/golang-svc-lb.yaml
@@ -1,0 +1,16 @@
+---
+  apiVersion: v1
+  kind: Service
+  metadata:
+    name: golang-service
+    labels:
+      app: golang-app
+  spec:
+    selector:
+      app: golang-app
+    type: LoadBalancer
+    ports:
+    - nodePort: 31000
+      port: 8080
+      targetPort: 8080
+...


### PR DESCRIPTION
Hi Team,

I've added Docker file and k8s manifest files. In order to deploy the Go-cal application in a Kubernetes cluster. 

Deploying Go-cal container on Kubernetes:

1. Build Docker image: 
# docker build -t srikanthdevops99/golang:v1 .

2. Deploying Go-cal Container in a K8s
#kubectl create -f golang-deploy.yaml 

3. Expose the deployment as service. This will create an ELB in front of those containers and allow us to publicly access them:
#kubectl create -f golang-svc-lb.yaml

